### PR TITLE
fix: incorrect dependency for Radix Sidebar

### DIFF
--- a/apps/www/public/r/radix-sidebar.json
+++ b/apps/www/public/r/radix-sidebar.json
@@ -8,7 +8,7 @@
     "radix-ui",
     "class-variance-authority",
     "lucide-react",
-    "motion/react"
+    "motion"
   ],
   "registryDependencies": [
     "https://animate-ui.com/r/radix-sheet",


### PR DESCRIPTION
Hi! I noticed when trying to install the Radix Sidebar component that the dependency in the registry object for motion was wrong; `motion/react` was present where `motion` should be, causing the shadcn CLI to crash. I've fixed the mistake in this PR.