### PR TITLE
Tell tooltip primitive what side to pop out of

### DIFF
--- a/packages/ui/src/components/ui/tooltip.tsx
+++ b/packages/ui/src/components/ui/tooltip.tsx
@@ -43,6 +43,7 @@ function TooltipContent({
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
+        side={side}
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(


### PR DESCRIPTION
Currently the code says to make the tooltip pop out right but unless we specify the tooltip side to the tooltip primitive, the side doesn't actually apply.